### PR TITLE
pretty in_port

### DIFF
--- a/src/dr_prettify.py
+++ b/src/dr_prettify.py
@@ -62,9 +62,17 @@ def pretty_ip_protocol(p):
     else:
         return p
 
+# Need configue NUM_OF_VFS to 0, and the SF_BASE_INDEX starts from
+# NUM_OF_VFS + 2, here 2 is for PF and uplink.
+NUM_OF_VFS = 0
+SF_BASE_INDEX = NUM_OF_VFS + 2
+
 def pretty_source_vport(regc0):
     source_vport = (int(regc0, 16) >> 16) - 1
-    source_vport = "(0x%x)," % (source_vport-1 if source_vport != 0 else source_vport)
+    if source_vport == 0:
+        source_vport = "pf"
+    elif source_vport >= SF_BASE_INDEX:
+        source_vport = "sf%d" % (source_vport - SF_BASE_INDEX)
     return source_vport
 
 def pretty_l3_type(t):


### PR DESCRIPTION
Currently hardcode to translate in_port number to sf name. The sf name
translation based on sf base index which for single pf is 2 +
/sys/bus/pci/devices/0000\:08\:00.0/sriov_totalvfs

Signed-off-by: Sean Zhang <xiazhang@nvidia.com>