### PR TITLE
add support for encap value parser of L3 DECAP

### DIFF
--- a/mlx_steering_dump_parser.py
+++ b/mlx_steering_dump_parser.py
@@ -201,6 +201,7 @@ def parse_domain(csv_reader, domain_obj=None, verbose=0):
             dump_ctx.rule.add_action(dr_obj)
             if dr_rec_type in [DR_DUMP_REC_TYPE_ACTION_ENCAP_L2,
                                DR_DUMP_REC_TYPE_ACTION_ENCAP_L3,
+                               DR_DUMP_REC_TYPE_ACTION_DECAP_L3,
                                DR_DUMP_REC_TYPE_ACTION_CTR,
                                DR_DUMP_REC_TYPE_ACTION_MODIFY_HDR]:
                dr_obj.add_dump_ctx(dump_ctx)

--- a/src/dr_action.py
+++ b/src/dr_action.py
@@ -156,8 +156,15 @@ class dr_dump_action_decap_l3(dr_obj):
         keys = ["dr_dump_rec_type", "id", "rule_id", "rewrite_index"]
         self.data = dict(zip(keys, data + [None] * (len(keys) - len(data))))
 
+    def add_dump_ctx(self, dump_ctx):
+        self.dump_ctx = dump_ctx
+
     def dump_str(self):
-        return "DECAP_L3, rewrite index %s" % (_srd(self.data, "rewrite_index"))
+        if ( (_srd(self.data, "id")) in self.dump_ctx.encap_decap.keys()):
+           out_str = self.dump_ctx.encap_decap[(_srd(self.data, "id"))]
+        else:
+           out_str = "parse l3decap error!"
+        return "DECAP_L3(%s), rewrite index %s" % (out_str, _srd(self.data, "rewrite_index"))
 
 
 class dr_dump_action_encap_l2(dr_obj):

--- a/src/parsers/mlx5_ifc_parser.py
+++ b/src/parsers/mlx5_ifc_parser.py
@@ -445,8 +445,8 @@ def mlx5_ifc_encap_decap(bin_str):
         return
 
     _len = len(bin_str)
-    if _len >= 108:
-        #mac + vlan + ip
+    if _len >= 108 or _len == (ETH_HDR_LEN + VLAN_HDR_LEN):
+        #mac + vlan + ip or mac + vlan
         has_vlan = True
     else:
         #mac + ip
@@ -459,6 +459,15 @@ def mlx5_ifc_encap_decap(bin_str):
         ret["ethtype"] = (bin_str[32: 36])  # 0x0800; ipv4, 0x86DD, ipv6
     else:
         ret["ethtype"] = (bin_str[24: 28])  # 0x0800; ipv4, 0x86DD, ipv6
+
+    if _len <= (ETH_HDR_LEN + VLAN_HDR_LEN):
+        if has_vlan:
+            str = "l2_push(dmac=%s, smac=%s, vid=%s, type=%s)" % \
+                           (ret["dmac"], ret["smac"], ret["vid"], ret["ethtype"])
+        else:
+            str = "l2_push(dmac=%s, smac=%s, type=%s)" % \
+                           (ret["dmac"], ret["smac"], ret["ethtype"])
+        return str
 
     if has_vlan:
         length += (ETH_HDR_LEN + VLAN_HDR_LEN)


### PR DESCRIPTION
L3 DECAP is combined with tunnel header decap and L2 header encap,
this patch add parser the encapsulated L2 header.

Signed-off-by: Jiawei Wang <jiaweiw@nvidia.com>

RM： https://redmine.mellanox.com/issues/3134888