### PR TITLE
SWS: Support python2, also support dr_trigger function

### DIFF
--- a/mlx_steering_dump_parser.py
+++ b/mlx_steering_dump_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2020 Mellanox Technologies, Inc.  All rights reserved.
 #

--- a/src/dr_trigger.py
+++ b/src/dr_trigger.py
@@ -141,3 +141,19 @@ def trigger_dump(s_pid, s_port, path, s_flow_ptr):
     dump_file.close()
     sock.close()
     return path
+
+def main():
+    if len(sys.argv) < 4:
+        print("Example:\n\tpython dr_trigger.py <DPDK_PID> <DPDK_PORT> <dump_file>")
+        sys.exit(1)
+
+    pid = int(sys.argv[1])
+    port = int(sys.argv[2])
+    dump_path = sys.argv[3]
+    _flow_ptr = 0
+    trigger_dump(pid, port, dump_path, _flow_ptr)
+
+    print("Done.")
+
+if __name__ == "__main__":
+    main()

--- a/src/dr_utilities.py
+++ b/src/dr_utilities.py
@@ -173,3 +173,6 @@ def hex_2_bin(hex_str):
     return bin_str
 
 
+#Use the % for printing instead of hex() func here to not get the trailing L for Long numbers
+def to_hex(_int):
+    return "0x%x" % _int

--- a/src/parsers/dr_matcher_mask_parser.py
+++ b/src/parsers/dr_matcher_mask_parser.py
@@ -30,7 +30,7 @@
 
 from socket import ntohl
 from src import dr_prettify
-from src.dr_utilities import hex_2_bin
+from src.dr_utilities import hex_2_bin, to_hex
 
 
 def little_endian_32(hex_str):
@@ -40,7 +40,7 @@ def little_endian_32(hex_str):
 
 def get_bits_at(data, i, j, m, n):
     bin_val = hex_2_bin(data[i: j])
-    bin_val = hex(int(bin_val[m: n], 2))
+    bin_val = to_hex(int(bin_val[m: n], 2))
     return bin_val
 
 

--- a/src/parsers/dr_ste_v1_parser.py
+++ b/src/parsers/dr_ste_v1_parser.py
@@ -31,6 +31,7 @@
 from src.parsers.dr_ste_v1_tag_parser import mlx5_ste_v1_tag_parser
 from src.dr_constants import *
 from src.parsers.dr_ste_v1_actions_parser import mlx5_ifc_ste_v1_action_bits_parser
+from src.dr_utilities import to_hex
 
 
 def mlx5_ifc_ste_v1_unsupported_ste():
@@ -41,35 +42,35 @@ def mlx5_ifc_ste_v1_unsupported_ste():
 
 def mlx5_ifc_ste_v1_match_bwc_bits_parser(bin_str, definer_id, raw):
     ret = {}
-    ret["entry_format"] = hex(int(bin_str[0: 8], 2))
-    ret["counter_id"] = hex(int(bin_str[8: 32], 2))
+    ret["entry_format"] = to_hex(int(bin_str[0: 8], 2))
+    ret["counter_id"] = to_hex(int(bin_str[8: 32], 2))
 
-    ret["miss_address_63_48"] = hex(int(bin_str[32: 48], 2))
-    ret["match_definer_ctx_idx"] = hex(int(bin_str[48: 56], 2))
-    ret["miss_address_39_32"] = hex(int(bin_str[56: 64], 2))
+    ret["miss_address_63_48"] = to_hex(int(bin_str[32: 48], 2))
+    ret["match_definer_ctx_idx"] = to_hex(int(bin_str[48: 56], 2))
+    ret["miss_address_39_32"] = to_hex(int(bin_str[56: 64], 2))
 
-    ret["miss_address_31_6"] = hex(int(bin_str[64: 90], 2))
-    ret["reserved_at_5a"] = hex(int(bin_str[90: 91], 2))
-    ret["match_polarity"] = hex(int(bin_str[91: 92], 2))
-    ret["reparse"] = hex(int(bin_str[92: 93], 2))
-    ret["reserved_at_5d"] = hex(int(bin_str[93: 96], 2))
+    ret["miss_address_31_6"] = to_hex(int(bin_str[64: 90], 2))
+    ret["reserved_at_5a"] = to_hex(int(bin_str[90: 91], 2))
+    ret["match_polarity"] = to_hex(int(bin_str[91: 92], 2))
+    ret["reparse"] = to_hex(int(bin_str[92: 93], 2))
+    ret["reserved_at_5d"] = to_hex(int(bin_str[93: 96], 2))
 
-    ret["next_table_base_63_48"] = hex(int(bin_str[96: 112], 2))
-    ret["hash_definer_ctx_idx"] = hex(int(bin_str[112: 120], 2))
-    ret["next_table_base_39_32_size"] = hex(int(bin_str[120: 128], 2))
+    ret["next_table_base_63_48"] = to_hex(int(bin_str[96: 112], 2))
+    ret["hash_definer_ctx_idx"] = to_hex(int(bin_str[112: 120], 2))
+    ret["next_table_base_39_32_size"] = to_hex(int(bin_str[120: 128], 2))
 
-    ret["next_table_base_31_5_size"] = hex(int(bin_str[128: 155], 2))
-    ret["hash_type"] = hex(int(bin_str[155: 157], 2))
-    ret["hash_after_actions"] = hex(int(bin_str[157: 158], 2))
-    ret["reserved_at_9e"] = hex(int(bin_str[158: 160], 2))
+    ret["next_table_base_31_5_size"] = to_hex(int(bin_str[128: 155], 2))
+    ret["hash_type"] = to_hex(int(bin_str[155: 157], 2))
+    ret["hash_after_actions"] = to_hex(int(bin_str[157: 158], 2))
+    ret["reserved_at_9e"] = to_hex(int(bin_str[158: 160], 2))
 
-    ret["byte_mask"] = hex(int(bin_str[160: 176], 2))
-    ret["next_entry_format"] = hex(int(bin_str[176: 177], 2))
-    ret["mask_mode"] = hex(int(bin_str[177: 178], 2))
-    ret["gvmi"] = hex(int(bin_str[178: 192], 2))
+    ret["byte_mask"] = to_hex(int(bin_str[160: 176], 2))
+    ret["next_entry_format"] = to_hex(int(bin_str[176: 177], 2))
+    ret["mask_mode"] = to_hex(int(bin_str[177: 178], 2))
+    ret["gvmi"] = to_hex(int(bin_str[178: 192], 2))
 
-    ret["action0"] = hex(int(bin_str[192: 224], 2))
-    ret["action1"] = hex(int(bin_str[224: 256], 2))
+    ret["action0"] = to_hex(int(bin_str[192: 224], 2))
+    ret["action1"] = to_hex(int(bin_str[224: 256], 2))
     ret["actions"] = mlx5_ifc_ste_v1_action_bits_parser([ret["action0"], ret["action1"]])
     tag = bin_str[256: 384]
     lookup_type = int(bin_str[0: 8] + bin_str[48: 56], 2)
@@ -80,33 +81,31 @@ def mlx5_ifc_ste_v1_match_bwc_bits_parser(bin_str, definer_id, raw):
 
 def mlx5_ifc_ste_v1_match_bits_parser(bin_str, definer_id, raw):
     ret = {}
-    ret["entry_format"] = hex(int(bin_str[0: 8], 2))
-    ret["counter_id"] = hex(int(bin_str[8: 32], 2))
+    ret["entry_format"] = to_hex(int(bin_str[0: 8], 2))
+    ret["counter_id"] = to_hex(int(bin_str[8: 32], 2))
 
-    ret["miss_address_63_48"] = hex(int(bin_str[32: 48], 2))
-    ret["match_definer_ctx_idx"] = hex(int(bin_str[48: 56], 2))
-    ret["miss_address_39_32"] = hex(int(bin_str[56: 64], 2))
+    ret["miss_address_63_48"] = to_hex(int(bin_str[32: 48], 2))
+    ret["match_definer_ctx_idx"] = to_hex(int(bin_str[48: 56], 2))
+    ret["miss_address_39_32"] = to_hex(int(bin_str[56: 64], 2))
 
-    ret["miss_address_31_6"] = hex(int(bin_str[64: 90], 2))
-    ret["reserved_at_5a"] = hex(int(bin_str[90: 91], 2))
-    ret["match_polarity"] = hex(int(bin_str[91: 92], 2))
-    ret["reparse"] = hex(int(bin_str[92: 93], 2))
-    ret["reserved_at_5d"] = hex(int(bin_str[93: 96], 2))
+    ret["miss_address_31_6"] = to_hex(int(bin_str[64: 90], 2))
+    ret["reserved_at_5a"] = to_hex(int(bin_str[90: 91], 2))
+    ret["match_polarity"] = to_hex(int(bin_str[91: 92], 2))
+    ret["reparse"] = to_hex(int(bin_str[92: 93], 2))
+    ret["reserved_at_5d"] = to_hex(int(bin_str[93: 96], 2))
 
-    ret["next_table_base_63_48"] = hex(int(bin_str[96: 112], 2))
-    ret["hash_definer_ctx_idx"] = hex(int(bin_str[112: 120], 2))
-    ret["next_table_base_39_32_size"] = hex(int(bin_str[120: 128], 2))
+    ret["next_table_base_63_48"] = to_hex(int(bin_str[96: 112], 2))
+    ret["hash_definer_ctx_idx"] = to_hex(int(bin_str[112: 120], 2))
+    ret["next_table_base_39_32_size"] = to_hex(int(bin_str[120: 128], 2))
 
-    ret["next_table_base_31_5_size"] = hex(int(bin_str[128: 155], 2))
-    ret["hash_type"] = hex(int(bin_str[155: 157], 2))
-    ret["hash_after_actions"] = hex(int(bin_str[157: 158], 2))
-    ret["reserved_at_9e"] = hex(int(bin_str[158: 160], 2))
+    ret["next_table_base_31_5_size"] = to_hex(int(bin_str[128: 155], 2))
+    ret["hash_type"] = to_hex(int(bin_str[155: 157], 2))
+    ret["hash_after_actions"] = to_hex(int(bin_str[157: 158], 2))
+    ret["reserved_at_9e"] = to_hex(int(bin_str[158: 160], 2))
 
-    ret["action0"] = hex(int(bin_str[160: 192], 2))
-
-    ret["action1"] = hex(int(bin_str[192: 224], 2))
-
-    ret["action2"] = hex(int(bin_str[224: 256], 2))
+    ret["action0"] = to_hex(int(bin_str[160: 192], 2))
+    ret["action1"] = to_hex(int(bin_str[192: 224], 2))
+    ret["action2"] = to_hex(int(bin_str[224: 256], 2))
 
     ret["actions"] = mlx5_ifc_ste_v1_action_bits_parser([ret["action0"], ret["action1"], ret["action2"]])
 

--- a/src/parsers/mlx5_ifc_parser.py
+++ b/src/parsers/mlx5_ifc_parser.py
@@ -4,7 +4,7 @@
 from socket import ntohl
 
 from src import dr_prettify
-from src.dr_utilities import hex_2_bin
+from src.dr_utilities import hex_2_bin, to_hex
 import ctypes
 import re
 from src.dr_prettify import pretty_ip, pretty_mac
@@ -17,7 +17,7 @@ def little_endian_32(hex_str):
 
 def get_bits_at(data, i, j, m, n):
     bin_val = hex_2_bin(data[i: j])
-    bin_val = hex(int(bin_val[m: n], 2))
+    bin_val = to_hex(int(bin_val[m: n], 2))
     return bin_val
 
 


### PR DESCRIPTION
Changed a little bit in the code to support python2, also added support for dr_trigger function to be called as a stand alone function.
Example:
	python dr_trigger.py <DPDK_PID> <DPDK_PORT> <dump_file>

Signed-off-by: Hamdan Igbaria <hamdani@nvidia.com>