### PR TITLE
HWS: Change rule verbosity printings, and fix address calculation

### DIFF
--- a/hws/src/dr_hw_resources.py
+++ b/hws/src/dr_hw_resources.py
@@ -44,7 +44,7 @@ class dr_parse_address():
         return self.data.get('id')
 
     def load_to_db(self):
-        _term_dest_db[self.get_addr()] = {'type': self.get_type(), 'id': self.get_id()}
+        _term_dest_db[self.get_addr()] = {'type': self.get_type(), 'id': int(self.get_id(), 16)}
 
 class dr_parse_stc():
     def __init__(self, data):

--- a/hws/src/dr_rule.py
+++ b/hws/src/dr_rule.py
@@ -23,9 +23,31 @@ class dr_parse_rule():
             self.tx_ste_arr.append(ste)
 
 
+    def compress_stes(self, verbosity, tabs, rx):
+        _str = ""
+        _ste = None
+        ste_arr = self.rx_ste_arr if rx else self.tx_ste_arr
+
+	for ste in ste_arr:
+            if _ste == None:
+                _ste = ste
+            else:
+                _ste.fields_dic.update(ste.fields_dic)
+                _ste.action_arr.extend(ste.action_arr)
+        if _ste != None:
+            _str += _ste.tree_print(verbosity, tabs, 'RX' if rx else 'TX', False)
+
+	return _str
+
+
     def tree_print(self, verbosity, tabs):
         _str = tabs + self.dump_str(verbosity)
         tabs = tabs + TAB
+
+        if verbosity < 3:
+            _str += self.compress_stes(verbosity, tabs, True)
+            _str += self.compress_stes(verbosity, tabs, False)
+            return _str
 
         for ste in self.rx_ste_arr:
             _str += ste.tree_print(verbosity, tabs, 'RX STE ')

--- a/hws/src/dr_ste.py
+++ b/hws/src/dr_ste.py
@@ -79,7 +79,7 @@ def fields_handler(_fields, show_field_val=False):
 
 def ste_hit_addr_calc(next_table_base_63_48, next_table_base_39_32, next_table_base_31_5):
     hit_addr = next_table_base_39_32 << 32
-    hit_addr |= next_table_base_31_5
+    hit_addr |= (next_table_base_31_5 << 5)
     hit_addr = (hit_addr >> 6) & 0xffffffff
 
     return hit_addr
@@ -173,10 +173,18 @@ class dr_parse_ste():
         self.miss_addr = parsed_ste["miss_addr"]
         self.fields_dic = parsed_ste.get("parsed_tag")
         self.action_arr = parsed_ste.get("actions")
+        self.fix_data()
 
-    def dump_str(self, verbosity, prefix='STE '):
-        _str = prefix + self.data.get("id") + ':\n'
-        return _str
+    def fix_data(self):
+        obj = _term_dest_db.get(self.hit_addr)
+        if obj != None:
+            self.action_arr.append(action_pretiffy(obj))
+
+    def dump_str(self, verbosity, prefix='STE ', ste_info=True):
+        _str = prefix
+        if ste_info:
+            _str += self.data.get("id")
+        return _str + ':\n'
 
     def dump_actions(self, verbosity, tabs):
         _str = tabs + 'Actions:\n'
@@ -187,11 +195,6 @@ class dr_parse_ste():
             if action != '':
                 _str += _tabs + action
                 flag = True
-
-        obj = _term_dest_db.get(self.hit_addr)
-        if obj != None:
-            _str += _tabs + obj.get("type") + ': ' + obj.get("id") + '\n'
-            flag = True
 
         if flag:
             return _str
@@ -224,8 +227,8 @@ class dr_parse_ste():
 
         return _str
 
-    def tree_print(self, verbosity, tabs, prefix=None):
-        _str = tabs + self.dump_str(verbosity, prefix)
+    def tree_print(self, verbosity, tabs, prefix=None, ste_info=True):
+        _str = tabs + self.dump_str(verbosity, prefix, ste_info)
         tabs = tabs + TAB
 
         _str += self.dump_fields(verbosity, tabs)


### PR DESCRIPTION
Change rule verbosity printings to show STE's in 3 v's, in less verbosity show tags and actions unified for all the rule STE's. Also fix hit address calculation.

Signed-off-by: Hamdan Igbaria <hamdani@nvidia.com>