### PR TITLE
HWS: Allow dumping all rte eth ports

### DIFF
--- a/hws/mlx_hw_steering_parser.py
+++ b/hws/mlx_hw_steering_parser.py
@@ -188,7 +188,7 @@ def parse_args():
     parser.add_argument("-pid", dest="dpdk_pid", type=int, default=-1,
                         help="Trigger DPDK app <PID>.")
     parser.add_argument("-port", dest="dpdk_port", type=int, default=0,
-                        help="Trigger DPDK app <PORT> (must provide PID with -pid).")
+                        help="Trigger DPDK app <PORT> newer dpdk supports -1 for all ports (must provide PID with -pid).")
     parser.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                         help='Show this help message and exit.')
 

--- a/hws/src/dr_trigger.py
+++ b/hws/src/dr_trigger.py
@@ -126,6 +126,10 @@ def trigger_dump(s_pid, s_port, path, s_flow_ptr):
     global server_pid
     global flow_ptr
 
+    # DPDK support dumping all ports if uint16_max is used
+    if s_port == -1:
+        s_port = int(0xffff)
+
     port = s_port
     server_pid = s_pid
     flow_ptr = s_flow_ptr


### PR DESCRIPTION
When setting port_id to 0xffff new dpdk will iterate over all of the available ports and dump them.
To not over complicate dump tool user -1 will indicate all ports.

Dump logic is part of mlx5_socket.c mlx5_pmd_socket_handle.