### PR TITLE
HWS: fix division by zero in progress bar

### DIFF
--- a/hws/src/dr_visual.py
+++ b/hws/src/dr_visual.py
@@ -5,6 +5,9 @@ PROGRESS_BAR_CHAR = "="
 
 
 def interactive_progress_bar(index, total, title = ''):
+    if total == 0:
+        return
+
     percent = int(100 * (index / total))
     completed = int(PROGRESS_BAR_LENGTH * (index / total))
     bar = PROGRESS_BAR_CHAR * completed + '-' * (PROGRESS_BAR_LENGTH - completed)


### PR DESCRIPTION
In case that total is zero return and do not proceed with showing the progress bar, because this will lead to division by zero.