### PR TITLE
HWS: fix address calculation, and change struct naming

### DIFF
--- a/hws/src/dr_common.py
+++ b/hws/src/dr_common.py
@@ -152,13 +152,13 @@ STC_ACTION_JUMP_TO_FLOW_TABLE = '82'
 STC_ACTION_JUMP_TO_VPORT = '85'
 
 
-class SteLocation():
+class ste_location():
     def __init__(self, gvmi, address):
         self.gvmi = gvmi
         self.gvmi_str = str(gvmi)
         # This field is not currently used:
         # self.address = address
-        self.index = address >> 6
+        self.index = (address >> 6) & 0xffffffff
         # This field is not currently used:
         # If it becomes used, bits 47:40 need to be found somewhere.
         # self.global_va = (gvmi << 48) | address
@@ -177,14 +177,14 @@ def miss_location_calc(miss_address_63_48, miss_address_39_32, miss_address_31_6
     gvmi = miss_address_63_48
     address = miss_address_39_32 << 32
     address |= miss_address_31_6 << 6
-    return SteLocation(gvmi, address)
+    return ste_location(gvmi, address)
 
 
 def hit_location_calc(next_table_base_63_48, next_table_base_39_32, next_table_base_31_5):
     gvmi = next_table_base_63_48
     address = next_table_base_39_32 << 32
     address |= next_table_base_31_5 << 5
-    return SteLocation(gvmi, address)
+    return ste_location(gvmi, address)
 
 
 def call_resource_dump(dev, dev_name, segment, index1, num_of_obj1, num_of_obj2, depth):


### PR DESCRIPTION
Fix STE address index calculation by taking only 32 bits. Change struct naming, from SteLocation to ste_location.