### PR TITLE
Added support for mstresourcedump and variants

### DIFF
--- a/hws/mlx_hw_steering_parser.py
+++ b/hws/mlx_hw_steering_parser.py
@@ -201,7 +201,7 @@ def validate_env_caps():
             print('MFT Error')
             exit()
         output = output.split(', ')
-        if output[0] != 'resourcedump':
+        if 'resourcedump' not in output[0]:
             print('Can not Dump HW resources, no MFT')
             exit()
 


### PR DESCRIPTION
At the present moment, only a file that strictly versions itself as resourcedump will pass the MFT check. However, the mellanox mstflint package advertises itself as mstresourcedump.  This change ensures that any string containing resourcedump will pass the name check.