### PR TITLE
Add ability to use relative file paths

### DIFF
--- a/hws/mlx_hw_steering_dump
+++ b/hws/mlx_hw_steering_dump
@@ -1,4 +1,26 @@
-#!/bin/sh
+#!/bin/bash
+ORIG_PATH=$(pwd)
 cd /usr/share/mlx-steering-dump/hws
-exec ./mlx_hw_steering_parser.py "$@"
+
+modified_args=()
+on_filename=0
+
+for arg in "$@"; do
+        if [ "$arg" = "-f" ]; then
+                on_filename=1
+                modified_args+=("$arg")
+        elif [ $on_filename -eq 1 ]; then
+                if [ -f "$ORIG_PATH/$arg" ]; then
+                        absolute_path=($ORIG_PATH/$arg)
+                        modified_args+=("$absolute_path")
+                else
+                        modified_args+=("$arg")
+                        on_filename=0
+                fi
+        else
+                modified_args+=("$arg")
+        fi
+done
+
+exec ./mlx_hw_steering_parser.py "${modified_args[@]}"
 

--- a/hws/mlx_hw_steering_dump
+++ b/hws/mlx_hw_steering_dump
@@ -10,7 +10,9 @@ for arg in "$@"; do
                 on_filename=1
                 modified_args+=("$arg")
         elif [ $on_filename -eq 1 ]; then
-                if [ -f "$ORIG_PATH/$arg" ]; then
+                if [ -f "$arg" ]; then
+                        modified_args+=("$arg")
+                elif [ -f "$ORIG_PATH/$arg" ]; then
                         absolute_path=($ORIG_PATH/$arg)
                         modified_args+=("$absolute_path")
                 else

--- a/sws/mlx_steering_dump
+++ b/sws/mlx_steering_dump
@@ -1,4 +1,25 @@
-#!/bin/sh
+#!/bin/bash
+ORIG_PATH=$(pwd)
 cd /usr/share/mlx-steering-dump/sws
-exec ./mlx_steering_dump_parser.py "$@"
 
+modified_args=()
+on_filename=0
+
+for arg in "$@"; do
+        if [ "$arg" = "-f" ]; then
+                on_filename=1
+                modified_args+=("$arg")
+        elif [ $on_filename -eq 1 ]; then
+                if [ -f "$ORIG_PATH/$arg" ]; then
+                        absolute_path=($ORIG_PATH/$arg)
+                        modified_args+=("$absolute_path")
+                else
+                        modified_args+=("$arg")
+                        on_filename=0
+                fi
+        else
+                modified_args+=("$arg")
+        fi
+done
+
+exec ./mlx_steering_dump_parser.py "${modified_args[@]}" 

--- a/sws/mlx_steering_dump
+++ b/sws/mlx_steering_dump
@@ -10,7 +10,9 @@ for arg in "$@"; do
                 on_filename=1
                 modified_args+=("$arg")
         elif [ $on_filename -eq 1 ]; then
-                if [ -f "$ORIG_PATH/$arg" ]; then
+                if [ -f "$arg" ]; then
+                        modified_args+=("$arg")
+                elif [ -f "$ORIG_PATH/$arg" ]; then
                         absolute_path=($ORIG_PATH/$arg)
                         modified_args+=("$absolute_path")
                 else


### PR DESCRIPTION
Currently, mlx_steering_dump and mlx_hw_steering_dump only accept absolute file paths. This commit adds a check to see if the file specified with -f exists in the current directory and uses that as the -f input to the corresponding python script if so. If not, the original content of the -f argument is passed.