### PR TITLE
HWS: Support dump over DOCA with pid

### DIFF
--- a/hws/README.md
+++ b/hws/README.md
@@ -1,53 +1,53 @@
 # mlx_hw_steering_parser.py
 > This is HW steering parser and triggering for dump files in **CSV
-> format**. 
+> format**.
 > This tool triggers the app to dump the app specific data,
 > and also triggers the HW to dump the app HW data.
-> 
+>
 How to trigger the HW steering dump
 ===================================
 The dump can be triggered by calling the dump API directly via:
 >  mlx5dr_debug_dump function
 
-Also it can be triggered for a DPDK app via:
+Also it can be triggered for a DPDK/DOCA app via:
 
-    python mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file>
+    python mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file>
 
 **Example:**
 
  - Trigger a dump to a new CSV file and skip HW dump:
 
-        ./mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file> --skip_dump
+        ./mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file> --skip_dump
 
  - Parse an existing dump_file CSV:
 
         ./mlx_hw_steering_parser.py -f <dump_file> --skip_dump
 
- - Trigger a DPDK app to dump all the ports HWS app to a new CSV file and skip HW dump:
+ - Trigger a DPDK/DOCA app to dump all the ports HWS app to a new CSV file and skip HW dump:
 
-	./mlx_hw_steering_parser.py --pid <DPDK PID> --port -1 -f <dump_file> --skip_dump
+	./mlx_hw_steering_parser.py --pid <APP PID> --port -1 -f <dump_file> --skip_dump
 
- - Developer triggering and parsing a dump with HW resources from a DPDK app:
- 
-        ./mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file> -vvv
-        ./mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file> -vvv --extra_hw_res pat,arg
-   
+ - Developer triggering and parsing a dump with HW resources from a DPDK/DOCA app:
+
+        ./mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file> -vvv
+        ./mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file> -vvv --extra_hw_res pat,arg
+
  - Customer producing a full dump for developers to debug:
- 
-        ./mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file> --skip_parse
+
+        ./mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file> --skip_parse
 
  - Customer producing a control dump for developers to debug:
- 
-        ./mlx_hw_steering_parser.py --pid <DPDK PID> -f <dump_file> --skip_dump
-  
-  
+
+        ./mlx_hw_steering_parser.py --pid <APP PID> -f <dump_file> --skip_dump
+
+
  ***Please see below "Running syntax" for more info.***
- 
+
 Running syntax
 ==============
 
     ./mlx_hw_steering_parser.py -f <FILE_PATH> [-v] [--skip_dump] [-d DEVICE]
-                                [--pid DPDK_PID] [--port DPDK_PORT] [--skip_parse]
+                                [--pid APP_PID] [--port APP_PORT] [--skip_parse]
                                 [--extra_hw_res [pat, arg, all]] [-s] [-h]
 
 ***arguments:***
@@ -62,8 +62,8 @@ Running syntax
 | --skip_dump | Skip HW resources dumping |
 | --skip_parse | Skip HW dumped resources parsing |
 | -d DEVICE | Provide MST device, otherwise it will be guessed automatically |
-| --pid DPDK_PID | Trigger DPDK app <PID> |
-| --port DPDK_PORT | Trigger DPDK app <PORT> (must provide PID with -pid) |
+| --pid APP_PID | Trigger DPDK/DOCA app <PID> |
+| --port APP_PORT | Trigger DPDK/DOCA app <PORT> (must provide PID with -pid) |
 | --extra_hw_res [pat, arg, all] | Request extra HW resources to be dumped. For example: -extra_hw_res pat,arg |
 | -s | Show dump statistics, such as STE's distribution |
 | -h, --help | It will show the help message and exit |

--- a/hws/mlx_hw_steering_parser.py
+++ b/hws/mlx_hw_steering_parser.py
@@ -223,10 +223,10 @@ def parse_args():
                         help="Skip HW dumped resources parsing.")
     parser.add_argument("-d", dest="device", type=str, default="",
                         help="Provide MST device for HW resources dumping.")
-    parser.add_argument("--pid", dest="dpdk_pid", type=int, default=-1,
-                        help="Trigger DPDK app <PID>.")
-    parser.add_argument("--port", dest="dpdk_port", type=int, default=0,
-                        help="Trigger DPDK app <PORT> newer dpdk supports -1 for all ports (must provide PID with -pid).")
+    parser.add_argument("--pid", dest="app_pid", type=int, default=-1,
+                        help="Trigger DPDK/DOCA app <PID>.")
+    parser.add_argument("--port", dest="app_port", type=int, default=0,
+                        help="Trigger DPDK/DOCA app <PORT> newer dpdk, and doca supports -1 for all ports (must provide PID with -pid).")
     parser.add_argument("--extra_hw_res", type=str, default="", dest="extra_hw_res", metavar="[pat, arg, all]",
                         help = "Request extra HW resources to be dumped. For example: --extra_hw_res pat,arg")
     parser.add_argument("-s", action="store_true", default=False, dest="statistics",
@@ -275,10 +275,10 @@ def parse_args():
         _config_args["parse_hw_resources"] = False
         _config_args["load_hw_resources"] = False
 
-    if (args.dpdk_pid > 0):
-        if dr_trigger.trigger_dump(args.dpdk_pid, args.dpdk_port, args.file_path, 0) is None:
+    if (args.app_pid > 0):
+        if dr_trigger.trigger_dump(args.app_pid, args.app_port, args.file_path, 0) is None:
             sys.exit(-1)
-        _config_args["dpdk_pid"] = args.dpdk_pid
+        _config_args["app_pid"] = args.app_pid
 
     if (os.stat(args.file_path).st_size == 0):
         print("Empty input file, no data to parse")

--- a/hws/src/dr_trigger.py
+++ b/hws/src/dr_trigger.py
@@ -82,16 +82,21 @@ def fd_msg(flow_ptr, fd, port, prevent_py_gc):
 
 
 def connect_to_server(server_pid):
-    path = "/var/tmp/dpdk_net_mlx5_%d" % server_pid
-    if (os.path.exists(path) == False):
-        print("DPDK doesn't support steering dump trigger")
+    doca_path = "/var/tmp/doca_mlx5_hws_%d" % server_pid
+    dpdk_path = "/var/tmp/dpdk_net_mlx5_%d" % server_pid
+    if os.path.exists(doca_path) == True:
+        connect_path = doca_path
+    elif os.path.exists(dpdk_path) == True:
+        connect_path = dpdk_path
+    else:
+        print("Steering dump trigger is not supported!")
         sys.exit(1)
 
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
-        sock.connect(path)
+        sock.connect(connect_path)
     except OSError as msg:
-        print("failed to connect to DPDK server: %s" % msg)
+        print("failed to connect to server at address: %s" % connect_path)
         sys.exit(1)
     return sock
 
@@ -126,7 +131,7 @@ def trigger_dump(s_pid, s_port, path, s_flow_ptr):
     global server_pid
     global flow_ptr
 
-    # DPDK support dumping all ports if uint16_max is used
+    # DPDK/DOCA support dumping all ports if uint16_max is used
     if s_port == -1:
         s_port = int(0xffff)
 
@@ -148,7 +153,7 @@ def trigger_dump(s_pid, s_port, path, s_flow_ptr):
 
 def main():
     if len(sys.argv) < 4:
-        print("Example:\n\tpython dr_trigger.py <DPDK_PID> <DPDK_PORT> <dump_file>")
+        print("Example:\n\tpython dr_trigger.py <APP_PID> <APP_PORT> <dump_file>")
         sys.exit(1)
 
     pid = int(sys.argv[1])


### PR DESCRIPTION
DPDK is running a server with a socket ready to connect. When triggered by the application, it will use the DPDK dump tool only with pid.
This mechanism is implemented for DOCA, and this commit adds the needed support from the dump tool. When the DOCA context is present, there is no need to dump the DPDK context.
The README file is also changed, and the code was refactored to indicate support for both applications.