### PR TITLE
HWS: Fix DB not loading _flow_counter_indexes_dic

### DIFF
--- a/hws/src/dr_db.py
+++ b/hws/src/dr_db.py
@@ -52,23 +52,6 @@ class _ctx_db:
         self._counters_db = {}
 
     def load(self, _new):
-        self._definers = _new._definers
-        self._matchers = _new._matchers
-        self._col_matchers = _new._col_matchers
-        self._ft_indexes_arr = _new._ft_indexes_arr
-        self._fw_ste_indexes_arr = _new._fw_ste_indexes_arr
-        self._stc_indexes_arr = _new._stc_indexes_arr
-        self._fw_ste_db = _new._fw_ste_db
-        self._stes_range_db = _new._stes_range_db
-        self._tbl_type_db = _new._tbl_type_db
-        self._tbl_level_db = _new._tbl_level_db
-        self._term_dest_db = _new._term_dest_db
-        self._pattern_db = _new._pattern_db
-        self._argument_db = _new._argument_db
-        self._arg_obj_indexes_dic = _new._arg_obj_indexes_dic
-        self._total_matcher_match_fw_stes = _new._total_matcher_match_fw_stes
-        self._counters_db = _new._counters_db
-
-
+        self.__dict__ = _new.__dict__
 
 _db = _ctx_db()


### PR DESCRIPTION
Previously, the load function would not load the
_flow_counter_indexes_dic. Fix this and other similar bugs in the future
by copying the entire object's __dict__ instead of manually copying each
field.

Signed-off-by: Alexander Efimov <aefimov@nvidia.com>