### PR TITLE
HWS: Fix parsing of hit address of tables larger than 1

### DIFF
--- a/hws/src/dr_common.py
+++ b/hws/src/dr_common.py
@@ -206,6 +206,7 @@ def hit_location_calc(next_table_base_63_48, next_table_base_39_32, next_table_b
     gvmi = next_table_base_63_48
     address = next_table_base_39_32 << 32
     address |= next_table_base_31_5 << 5
+    address = address & (address - 1)
     return ste_location(gvmi, address)
 
 _segments_dic = {


### PR DESCRIPTION
Table size is reflected in the STE address fields, in case of address of table of size larger than 1 this address index calculation was done wrong, fix that in this patch by poping the size bit from the address.